### PR TITLE
Added Python3 support to ExtendedKey.

### DIFF
--- a/bip32utils/BIP32Key.py
+++ b/bip32utils/BIP32Key.py
@@ -41,7 +41,7 @@ class BIP32Key(object):
         I = hmac.new(b"Bitcoin seed", entropy, hashlib.sha512).digest()
         Il, Ir = I[:32], I[32:]
         # FIXME test Il for 0 or less than SECP256k1 prime field order
-        key = BIP32Key(secret=Il, chain=Ir, depth=0, index=0, fpr='\0\0\0\0', public=False)
+        key = BIP32Key(secret=Il, chain=Ir, depth=0, index=0, fpr=b'\0\0\0\0', public=False)
         if public:
             key.SetPublic()
         return key
@@ -285,14 +285,14 @@ class BIP32Key(object):
         if self.public is True and private is True:
             raise Exception("Cannot export an extended private key from a public-only deterministic key")
         version = EX_MAIN_PRIVATE if private else EX_MAIN_PUBLIC
-        depth = chr(self.depth)
+        depth = bytes(bytearray([self.depth]))
         fpr = self.parent_fpr
         child = struct.pack('>L', self.index)
         chain = self.C
         if self.public is True or private is False:
             data = self.PublicKey()
         else:
-            data = '\x00' + self.PrivateKey()
+            data = b'\x00' + self.PrivateKey()
         raw = version+depth+fpr+child+chain+data
         if not encoded:
             return raw


### PR DESCRIPTION
I missed this function.

How should issues be handled? AFAIK forks don't have an issue tracker on Github.

Current issues:

- Base58.decode doesn't work on Python3 (output is wrong) (I believe so anyways, it appears to be different from the Python2 output)
- Base58 should probably use bytearrays instead of concatenating to strings. 1. strings are immutable (so every concatenation is actually a copy+append) 2. Most things end up converted to bytes (immutable) or bytearrays (mutable) anyways. It also does a lot of converting to and from int to str (chr, ord), bytearrays are arrays of int (uint8?), so that would be resolved.
- dump is probably broken in Python3 (only because of it's use of str.encode("hex"))