### PR TITLE
Base58 decode to Use bytearray

### DIFF
--- a/bip32utils/BIP32Key.py
+++ b/bip32utils/BIP32Key.py
@@ -78,8 +78,11 @@ class BIP32Key(object):
             raise ValueError("unknown extended key version")
 
         # Extract remaining fields
-        #TODO python2 requires ord(raw[4])
-        depth = raw[4]
+        # Python 2.x compatibility
+        if type(raw[4]) == int:
+            depth = raw[4]
+        else:
+            depth = ord(raw[4])
         fpr = raw[5:9]
         child = struct.unpack(">L", raw[9:13])[0]
         chain = raw[13:45]

--- a/bip32utils/BIP32Key.py
+++ b/bip32utils/BIP32Key.py
@@ -78,7 +78,8 @@ class BIP32Key(object):
             raise ValueError("unknown extended key version")
 
         # Extract remaining fields
-        depth = ord(raw[4])
+        #TODO python2 requires ord(raw[4])
+        depth = raw[4]
         fpr = raw[5:9]
         child = struct.unpack(">L", raw[9:13])[0]
         chain = raw[13:45]

--- a/bip32utils/Base58.py
+++ b/bip32utils/Base58.py
@@ -6,7 +6,8 @@
 
 from hashlib import sha256
 
-__base58_alphabet = b'123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+__base58_alphabet = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+__base58_alphabet_bytes = b'123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
 __base58_radix = len(__base58_alphabet)
 
 
@@ -25,21 +26,17 @@ def __string_to_int(data):
 
 def encode(data):
     "Encode string into Bitcoin base58"
-    enc = bytearray()
+    enc = ''
     val = __string_to_int(data)
     while val >= __base58_radix:
         val, mod = divmod(val, __base58_radix)
-        enc.append(__base58_alphabet[mod]) 
+        enc = __base58_alphabet[mod] + enc
     if val:
-        enc.append(__base58_alphabet[val]) 
+        enc = __base58_alphabet[val] + enc
 
     # Pad for leading zeroes
     n = len(data)-len(data.lstrip(b'\0'))
-    # TODO python2 xrange
-    for i in range(n):
-        enc.append(__base58_alphabet[0])
-
-    return bytes(enc[::-1])
+    return enc+__base58_alphabet[0]*n
 
 
 def check_encode(raw):
@@ -52,7 +49,7 @@ def decode(data):
     "Decode Bitcoin base58 format to string"
     val = 0
     for (i, c) in enumerate(data[::-1]):
-        val += __base58_alphabet.find(c) * (__base58_radix**i)
+        val += __base58_alphabet_bytes.find(c) * (__base58_radix**i)
     dec = bytearray()
     while val >= 256:
         val, mod = divmod(val, 256)

--- a/bip32utils/Base58.py
+++ b/bip32utils/Base58.py
@@ -6,14 +6,15 @@
 
 from hashlib import sha256
 
-__base58_alphabet = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+__base58_alphabet = b'123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
 __base58_radix = len(__base58_alphabet)
 
 
 def __string_to_int(data):
     "Convert string of bytes Python integer, MSB"
     val = 0
-    
+   
+    # Python 2.x compatibility
     if type(data) == str:
         data = bytearray(data)
 
@@ -24,17 +25,21 @@ def __string_to_int(data):
 
 def encode(data):
     "Encode string into Bitcoin base58"
-    enc = ''
+    enc = bytearray()
     val = __string_to_int(data)
     while val >= __base58_radix:
         val, mod = divmod(val, __base58_radix)
-        enc = __base58_alphabet[mod] + enc
+        enc.append(__base58_alphabet[mod]) 
     if val:
-        enc = __base58_alphabet[val] + enc
+        enc.append(__base58_alphabet[val]) 
 
     # Pad for leading zeroes
     n = len(data)-len(data.lstrip(b'\0'))
-    return __base58_alphabet[0]*n + enc
+    # TODO python2 xrange
+    for i in range(n):
+        enc.append(__base58_alphabet[0])
+
+    return bytes(enc[::-1])
 
 
 def check_encode(raw):
@@ -48,13 +53,13 @@ def decode(data):
     val = 0
     for (i, c) in enumerate(data[::-1]):
         val += __base58_alphabet.find(c) * (__base58_radix**i)
-    dec = ''
+    dec = bytearray()
     while val >= 256:
         val, mod = divmod(val, 256)
-        dec = chr(mod) + dec
+        dec.append(mod)
     if val:
-        dec = chr(val) + dec
-    return dec
+        dec.append(val)
+    return bytes(dec[::-1])
 
 
 def check_decode(enc):


### PR DESCRIPTION
This change makes Base58 decode work on Python3, and results in a small (very small) speedup in Python2.

This PR also updates some comments to make it clear that encode accepts 'bytes' and ouputs 'str' and decode accepts 'str' and outputs 'bytes'.

As a small note, Python3 is about 50% faster than Python2 when encoding/decoding 10000 times! Yay!